### PR TITLE
Reword invalid formatting error.

### DIFF
--- a/src/commands/dupe.js
+++ b/src/commands/dupe.js
@@ -13,7 +13,7 @@ module.exports = {
     const message = await msg.channel.createMessage('Working on it...')
     try {
       const chunks = suffix.split(' ')
-      if (chunks.length < 2) return message.edit('Invalid formatting')
+      if (chunks.length < 2) return message.edit('Invalid formatting. Please make sure you have left a space between each suggestion ID.')
       if (chunks.length > 6) return message.edit("Can't multimerge more than 5 suggestions!")
       const target = await ZD.getSubmission(MB_CONSTANTS.determineID(chunks.pop()), ['users', 'topics'])
       if (chunks.includes(target.id.toString())) return message.edit("You've included the target ID in your dupes")


### PR DESCRIPTION
Makes the invalid formatting error clearer for new Custodians so they can understand what part of the command they have got wrong.

# Please check the following boxes
> All boxes are required

- [x] I agree to the [Contribution Guidelines](https://github.com/Dougley/MBv2/blob/master/.github/CONTRIBUTING.md) and to the [Code of Conduct](https://github.com/Dougley/MBv2/blob/master/.github/CODE_OF_CONDUCT.md)
- [x] I tested my code and I verified it's working to the best of my ability
- [x] I checked if my code doesn't violate the styleguide with `npm test`

# Describe your pull request

> This pull request makes it easier for new Custodians to see what part of the dupe command they have done wrong when they get the "invalid formatting error".

**Why is this change needed?**

>To make it easier for people who are new to see what part of the command they have done incorrectly at a glance.

**Does your pull request solve an open issue? If yes, please mention what one**

> See https://help.github.com/en/articles/closing-issues-using-keywords
